### PR TITLE
Change to call handleWindowCallback from adalContext

### DIFF
--- a/src/services/adal.service.ts
+++ b/src/services/adal.service.ts
@@ -58,15 +58,7 @@ export class AdalService {
     }
 
     public handleWindowCallback(): void {
-        let hash = window.location.hash;
-        if (this.adalContext.isCallback(hash)) {
-            let requestInfo = this.adalContext.getRequestInfo(hash);
-            this.adalContext.saveTokenFromHash(requestInfo);
-            if (requestInfo.requestType === this.adalContext.REQUEST_TYPE.LOGIN) {
-                this.updateDataFromCache(this.adalContext.config.loginResource);
-            } else if (requestInfo.requestType === this.adalContext.REQUEST_TYPE.RENEW_TOKEN) {
-            }
-        }
+        this.adalContext.handleWindowCallback();
     }
 
     public getCachedToken(resource: string): string {


### PR DESCRIPTION
handleWindowCallback was the odd one out and causing issue when redirected back to the authenticated page. The page redirect stops and shows id_token appended to redirect url. Calling the handleWindowCallback from adalContext will do the complete redirect to user's home page after reading relevant information from id_token hash.
